### PR TITLE
identify click outside unless button or span

### DIFF
--- a/web/src/hooks/useComponentVisible.js
+++ b/web/src/hooks/useComponentVisible.js
@@ -17,6 +17,11 @@ export default function useComponentVisible(initialIsVisible) {
   };
 
   const handleClickOutside = (event) => {
+    const element = event.target.nodeName;
+    if (element === 'SPAN' || element === 'BUTTON') {
+      return;
+    }
+
     if (ref.current && !ref.current.contains(event.target)) {
       setIsComponentVisible(false);
     }


### PR DESCRIPTION
Hook to identify click outside ActionsMenu was affecting buttons in modal overlay

fixes #10 